### PR TITLE
Add missing apt-get update step

### DIFF
--- a/cookbooks/aptupdate/recipes/default.rb
+++ b/cookbooks/aptupdate/recipes/default.rb
@@ -1,0 +1,3 @@
+execute "apt-get update" do
+  user "root"
+end

--- a/roles/graphing.rb
+++ b/roles/graphing.rb
@@ -1,6 +1,6 @@
 name "graphing"
 description "The base role for systems that serve graphs"
-run_list "recipe[graphite]", "recipe[statsd]"
+run_list "recipe[aptupdate]", "recipe[graphite]", "recipe[statsd]"
 #env_run_lists "prod" => ["recipe[apache2]"], "staging" => ["recipe[apache2::staging]"]
 default_attributes "graphite" => { "password" => "passwordz", "python_version" => "2.7" }
 #override_attributes "apache2" => { "max_children" => "50" }


### PR DESCRIPTION
The apt repository on is stale and so the install of python-django tries to get a missing version and fails. This change runs apt-get update before installing packages so that valid versions are fetched.
